### PR TITLE
Make Prettier ignore HTML files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 src/_includes/.webpack
+*.html

--- a/src/index.html
+++ b/src/index.html
@@ -12,11 +12,17 @@ layout: default.html
 </div>
 
 <main>
-	{% for font in fonts %} {% if font[1].axes.length != 0 %} {% include
-	interactive-controls.html %}
-	<hr />
-	{% endif %} {% endfor %} {% for font in fonts %} {% include
-	character-grid.html %}
-	<hr />
-	{% endfor %} {% include animation.html %}
+	{% for font in fonts %}
+		{% if font[1].axes.length != 0 %}
+			{% include interactive-controls.html %}
+			<hr />
+		{% endif %}
+	{% endfor %}
+
+	{% for font in fonts %}
+		{% include character-grid.html %}
+		<hr />
+	{% endfor %}
+
+	{% include animation.html %}
 </main>


### PR DESCRIPTION
It's doing more bad than good, reformatting Liquid loops and
complaining about valid HTML. So for now, disable it for HTML
until we find a more Liquid-compatible solution.