### PR TITLE
Clean out data files before generating new ones

### DIFF
--- a/_tools/generateFontData.js
+++ b/_tools/generateFontData.js
@@ -99,6 +99,10 @@ const findFontFile = async directory => {
 const main = async () => {
 	const fontFiles = process.argv[2] || (await findFontFile(fontsDirectory));
 
+	// Clear out old data files
+	console.log("Deleting old data files");
+	fs.rmdirSync(dataDirectory, { recursive: true });
+
 	// Initialise files
 	writeFile(
 		fontsStylesheetPath,


### PR DESCRIPTION
There's hardly ever a reason to run `yarn fontdata` and keep old
files (of removed fonts) around. So just nuke the dir before
generating new data.