### PR TITLE
Use proper font name

### DIFF
--- a/_tools/generateFontData.js
+++ b/_tools/generateFontData.js
@@ -93,7 +93,7 @@ const findFontFile = async directory => {
 
 const getMetaData = (fontData, fontFile) => {
 	return {
-		name: fontFile.name,
+		name: fontData.name,
 		selector: getSelector(fontData, true),
 		style: suggestFontStyle(fontFile.name)
 	};


### PR DESCRIPTION
Getting it from fontData (passed from *-support) instead of grabbing it from the filename, which can be totally different.

Will work by itself, but in https://github.com/kabisa/specimen-skeleton-support/pull/19 we change the name table entry where we derive the name from. So these two PRs go together, even if they work independently.