### PR TITLE
build:* and start:* need single quotes to work on macOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
 	"license": "MIT",
 	"scripts": {
 		"clean": "rimraf ./_site",
-		"build": "cross-env NODE_ENV=production ELEVENTY_ENV=production run-s clean build:*",
+		"build": "cross-env NODE_ENV=production ELEVENTY_ENV=production run-s clean 'build:*'",
 		"build:webpack": "webpack",
 		"build:eleventy": "eleventy",
-		"start": "cross-env NODE_ENV=development ELEVENTY_ENV=development npm-run-all clean build:webpack --parallel start:*",
+		"start": "cross-env NODE_ENV=development ELEVENTY_ENV=development npm-run-all clean build:webpack --parallel 'start:*'",
 		"start:webpack": "webpack -w",
 		"start:eleventy": "eleventy --serve",
 		"prettier": "prettier '{src/**/*.{js,css,json,html},*.js,*.json,*.html}'",


### PR DESCRIPTION
When running 'yarn build' or 'yarn start' on macOS with Bash & Node v21.1.0, you get an error because * gets interpreted as a glob pattern. Surround the specs with ' to make it work.

## What

Explain what changes inside the code, this can be as simple or complicated as you want as long as it's clear

## Why

Explain why these things are changes. This explanation is for your colleagues and your future self.

## Code Review

Please consider the following checklist when reviewing this Pull Request.  
More background and details [here](https://github.com/kabisa/kabisa-guide/blob/master/organization/process/code-review/README.md).

* [ ] Does the code **actually solve** the problem it was meant to solve?
* [ ] Is the code covered by **unit tests**? **Integration tests**?
* [ ] Does anything here need **documentation**? (Focus on *why*, not *what.*)
* [ ] Does any of this code deal with **privacy sensitive information** or affects **security**? Ask an additional reviewer.
* [ ] Is the code easy to **understand** and **change** in the future?
* [ ] Is the same code or concept **duplicated**? Find a balance between DRYness and readability.
* [ ] Does the code reasonably adhere to the Kabisa [**coding standards**](https://github.com/kabisa/kabisa-guide/blob/master/organization/process/code-review/README.md)?
* [ ] Be kind.
